### PR TITLE
feat: update @lando/php to ^1.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## {{ UNRELEASED_VERSION }} - [{{ UNRELEASED_DATE }}]({{ UNRELEASED_LINK }})
 
+* Updated to [@lando/php@1.12.0](https://github.com/lando/php/releases/tag/v1.12.0) for mod_headers/mod_expires and xdebug log fix
+
 ## v1.9.2 - [February 22, 2026](https://github.com/lando/backdrop/releases/tag/v1.9.2)
 
 * Updated `@lando/php` to `^1.11.1` [#87](https://github.com/lando/backdrop/issues/87)

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@lando/mariadb": "^1.7.0",
         "@lando/mssql": "^1.4.3",
         "@lando/mysql": "^1.6.0",
-        "@lando/php": "^1.11.1",
+        "@lando/php": "^1.12.0",
         "@lando/postgres": "^1.5.0",
         "lodash": "^4.17.21"
       },
@@ -1472,9 +1472,9 @@
       "license": "MIT"
     },
     "node_modules/@lando/php": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/@lando/php/-/php-1.11.1.tgz",
-      "integrity": "sha512-3l6oEj6iZxL4vj59YbOinfu4ktUXYfHe7UlP1W5wePTaQH9K+RBCg8eCsPBmliQzc9ltX6JqvDYrAx2KN5K8Dw==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@lando/php/-/php-1.12.0.tgz",
+      "integrity": "sha512-yHhjdtGv0zgylfOubbWz09ufTr8yfi7so262RDJT5P03T24LfHPOBLFLTtdI8I1k0kzH9phxhQ4aZyex9TMhsg==",
       "bundleDependencies": [
         "@lando/nginx",
         "lodash",
@@ -1491,7 +1491,7 @@
       }
     },
     "node_modules/@lando/php/node_modules/@lando/nginx": {
-      "version": "1.5.0",
+      "version": "1.6.0",
       "bundleDependencies": [
         "lodash"
       ],

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@lando/mariadb": "^1.7.0",
     "@lando/mssql": "^1.4.3",
     "@lando/mysql": "^1.6.0",
-    "@lando/php": "^1.11.1",
+    "@lando/php": "^1.12.0",
     "@lando/postgres": "^1.5.0",
     "lodash": "^4.17.21"
   },


### PR DESCRIPTION
## Changes

- Updated `@lando/php` to `^1.12.0`

## What's in @lando/php v1.12.0

- Enabled mod_headers and mod_expires Apache modules by default ([php#244](https://github.com/lando/php/pull/244))
- Fixed xdebug log file ownership issue when build_as_root or run_as_root creates /tmp/xdebug.log as root ([php#242](https://github.com/lando/php/pull/242))

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates the underlying `@lando/php` service dependency, which can change runtime behavior of the PHP/Apache container (modules enabled by default) and could impact downstream projects’ environments.
> 
> **Overview**
> Updates this plugin to use `@lando/php@^1.12.0` (and lockfile-resolves it), pulling in upstream fixes like enabling Apache `mod_headers`/`mod_expires` by default and correcting Xdebug log ownership behavior.
> 
> Adds an *unreleased* changelog entry documenting the dependency bump and its motivation.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5e93fbde15eb75c2dc03126877925bb6e02bd355. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->